### PR TITLE
Flights without gradingd are not training flights (#120 fixed again)

### DIFF
--- a/FlightJournal.Web/Controllers/TrainingLogController.cs
+++ b/FlightJournal.Web/Controllers/TrainingLogController.cs
@@ -115,8 +115,6 @@ namespace FlightJournal.Web.Controllers
 
             var allTrainingFlightIdsForThisPilot = db.AppliedExercises
                 .Select(x => x.FlightId)
-                .Union(db.TrainingFlightAnnotations
-                    .Select(y => y.FlightId))
                 .Distinct()
                 .Where(fid=>flightIdsWithThisPilot.Contains(fid))
                 .ToList();
@@ -128,6 +126,8 @@ namespace FlightJournal.Web.Controllers
             foreach (var f in theFlights)
             {
                 var ae = db.AppliedExercises.Where(x => x.FlightId == f.FlightId).Where(x => x.Grading != null && x.Grading.Value > 0);
+                if (ae.IsNullOrEmpty())
+                    continue;
                 var programName = string.Join(", ", ae.Select(x => x.Program.ShortName).Distinct()); // should be only one on a single flight, but...
                 var appliedLessons = ae.Select(x => x.Lesson).GroupBy(a => a).ToDictionary((g) => g.Key, g => g.Count()).OrderByDescending(d => d.Value).ToList();
                 var primaryLessonName = "";


### PR DESCRIPTION
A flight is only a training flight if AppliedExercises has data (i.e., at least one partial exercise has been graded).

Already fixed in TrainingLogHistoryController, but forgot this.