### PR TITLE
Aprs fixes

### DIFF
--- a/FlightJournal.Web/Aprs/AircraftEventHandler.cs
+++ b/FlightJournal.Web/Aprs/AircraftEventHandler.cs
@@ -39,7 +39,7 @@ namespace FlightJournal.Web.Aprs
                 // Check if any club at that location is using APRSTakeoffAndLanding
 
                 var flight = flights.Single();
-                Log.Information($"{nameof(AircraftEventHandler)} TAKEOFF: {flight.Plane.Registration} took off at {e.Time}");
+                Log.Information($"{nameof(AircraftEventHandler)} TAKEOFF: {flight.Plane.Registration} took off at {e.Time:o}");
                 if (_db.Clubs.Any(c => c.LocationId == flight.StartedFromId && c.UseAPRSTakeoffAndLanding))
                 {
                     flight.Departure = e.Time ?? DateTime.Now;
@@ -73,7 +73,7 @@ namespace FlightJournal.Web.Aprs
             if (flights.Count() == 1)
             {
                 var flight = flights.Single();
-                Log.Information($"{nameof(AircraftEventHandler)} LANDING: {flight.Plane.Registration} landed at {e.Time}");
+                Log.Information($"{nameof(AircraftEventHandler)} LANDING: {flight.Plane.Registration} landed at {e.Time:o}");
                 if (_db.Clubs.Any(c => c.LocationId == flight.LandedOnId && c.UseAPRSTakeoffAndLanding))
                 {
                     flight.Landing = e.Time ?? DateTime.Now;

--- a/FlightJournal.Web/Aprs/AprsListener.cs
+++ b/FlightJournal.Web/Aprs/AprsListener.cs
@@ -130,7 +130,14 @@ namespace FlightJournal.Web.Aprs
 
             var ae = new AircraftEvent(aircraft, e.Flight.StartTime);
             Log.Debug($"{nameof(AprsListener)}: {e.Flight.Aircraft} {ae.Aircraft.Info()} - Took off from ({e.Flight.DepartureLocation.Y:N4},{e.Flight.DepartureLocation.X:N4}) at {ae.Time:o}");
-            OnAircraftTakeoff?.Invoke(this, ae);
+            try
+            {
+                OnAircraftTakeoff?.Invoke(this, ae);
+            }
+            catch (Exception ex)
+            {
+                Log.Exception($"{nameof(AprsListener)}",  ex);
+            }
         }
 
         private void OnLanding(object sender, OnLandingEventArgs e)
@@ -139,7 +146,14 @@ namespace FlightJournal.Web.Aprs
 
             var ae = new AircraftEvent(aircraft, e.Flight.EndTime);
             Log.Debug($"{nameof(AprsListener)}: {e.Flight.Aircraft} {ae.Aircraft.Info()} - Landed at ({e.Flight.ArrivalLocation.Y:N4}, {e.Flight.ArrivalLocation.X:N4}) at {ae.Time:o}");
-            OnAircraftLanding?.Invoke(this, ae);
+            try{
+                OnAircraftLanding?.Invoke(this, ae);
+            }
+            catch (Exception ex)
+            {
+                Log.Exception($"{nameof(AprsListener)}", ex);
+            }
+
         }
 
         public void Start()

--- a/FlightJournal.Web/Aprs/AprsListener.cs
+++ b/FlightJournal.Web/Aprs/AprsListener.cs
@@ -87,7 +87,7 @@ namespace FlightJournal.Web.Aprs
                     {
                         var positionUpdate = new Skyhop.FlightAnalysis.Models.PositionUpdate(
                             e.AprsMessage.Callsign,
-                            e.AprsMessage.ReceivedDate,
+                            e.AprsMessage.ReceivedDate.ToUniversalTime(),
                             e.AprsMessage.Latitude.ToDegreesFixed(),
                             e.AprsMessage.Longitude.ToDegreesFixed(),
                             e.AprsMessage.Altitude.FeetAboveSeaLevel,
@@ -116,7 +116,7 @@ namespace FlightJournal.Web.Aprs
         {
             var lastPositionUpdate = e.Flight.PositionUpdates.OrderByDescending(q => q.TimeStamp).First();
             var aircraft = _catalog.AircraftInfo((e.Flight.Aircraft));
-            Log.Debug($"{nameof(AprsListener)}: {lastPositionUpdate.TimeStamp}: {e.Flight.Aircraft} {aircraft.Info()} - Radar contact at ({lastPositionUpdate.Latitude:N4}, {lastPositionUpdate.Longitude:N4}) @ {lastPositionUpdate.Altitude:N0}ft");
+            Log.Debug($"{nameof(AprsListener)}: {lastPositionUpdate.TimeStamp:o}: {e.Flight.Aircraft} {aircraft.Info()} - Radar contact at ({lastPositionUpdate.Latitude:N4}, {lastPositionUpdate.Longitude:N4}) @ {lastPositionUpdate.Altitude:N0}ft");
         }
         private void OnContactLost(object sender, OnContextDisposedEventArgs e)
         {
@@ -129,7 +129,7 @@ namespace FlightJournal.Web.Aprs
             var aircraft = _catalog.AircraftInfo((e.Flight.Aircraft));
 
             var ae = new AircraftEvent(aircraft, e.Flight.StartTime);
-            Log.Debug($"{nameof(AprsListener)}: {e.Flight.Aircraft} {ae.Aircraft.Info()} - Took off from ({e.Flight.DepartureLocation.Y:N4},{e.Flight.DepartureLocation.X:N4}) at {ae.Time}");
+            Log.Debug($"{nameof(AprsListener)}: {e.Flight.Aircraft} {ae.Aircraft.Info()} - Took off from ({e.Flight.DepartureLocation.Y:N4},{e.Flight.DepartureLocation.X:N4}) at {ae.Time:o}");
             OnAircraftTakeoff?.Invoke(this, ae);
         }
 
@@ -138,7 +138,7 @@ namespace FlightJournal.Web.Aprs
             var aircraft = _catalog.AircraftInfo((e.Flight.Aircraft));
 
             var ae = new AircraftEvent(aircraft, e.Flight.EndTime);
-            Log.Debug($"{nameof(AprsListener)}: {e.Flight.Aircraft} {ae.Aircraft.Info()} - Landed at ({e.Flight.ArrivalLocation.Y:N4}, {e.Flight.ArrivalLocation.X:N4}) at {ae.Time}");
+            Log.Debug($"{nameof(AprsListener)}: {e.Flight.Aircraft} {ae.Aircraft.Info()} - Landed at ({e.Flight.ArrivalLocation.Y:N4}, {e.Flight.ArrivalLocation.X:N4}) at {ae.Time:o}");
             OnAircraftLanding?.Invoke(this, ae);
         }
 

--- a/FlightJournal.Web/Global.asax.cs
+++ b/FlightJournal.Web/Global.asax.cs
@@ -18,6 +18,8 @@ namespace FlightJournal.Web
             ApplicationConfiguration.Config = AppConfig.CFG_DEBUG;
 #endif
             log4net.Config.XmlConfigurator.Configure();
+            log4net.GlobalContext.Properties["CONFIG"] = ApplicationConfiguration.Config;
+
             AreaRegistration.RegisterAllAreas();
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
             RouteConfig.RegisterRoutes(RouteTable.Routes);

--- a/FlightJournal.Web/Models/ListenerArea.cs
+++ b/FlightJournal.Web/Models/ListenerArea.cs
@@ -23,7 +23,7 @@ namespace FlightJournal.Web.Models
         public override string ToString()
         {
             return
-                $"({Latitude.ToString(CultureInfo.InvariantCulture)}, {Longitude.ToString(CultureInfo.InvariantCulture)}), radius {Radius.ToString(CultureInfo.InvariantCulture)} km";
+                $"({Latitude.ToString(CultureInfo.InvariantCulture)}, {Longitude.ToString(CultureInfo.InvariantCulture)}), radius {Radius.ToString(CultureInfo.InvariantCulture)} km ({Note})";
         }
     }
 

--- a/FlightJournal.Web/Web.Debug.config
+++ b/FlightJournal.Web/Web.Debug.config
@@ -30,11 +30,10 @@
 
 
   <log4net>
-    <root>
-      <!-- Do not disable file logging in debug mode -->
-      <!--<appender-ref ref="file" xdt:Transform="Remove"/>
-      <appender-ref ref="startland"  xdt:Transform="Remove"/>-->
-      <appender-ref ref="aiAppender"  xdt:Transform="Remove"/>
+    <root xdt:Transform="Replace">
+      <level value="ALL" />
+      <appender-ref ref="file" />
+      <appender-ref ref="startland" />
     </root>
   </log4net>
 </configuration>

--- a/FlightJournal.Web/Web.Demo.config
+++ b/FlightJournal.Web/Web.Demo.config
@@ -41,10 +41,7 @@
   </system.web>
 
   <log4net>
-    <root>
-      <appender-ref ref="file" xdt:Transform="Remove"/>
-      <appender-ref ref="startland"  xdt:Transform="Remove"/>
-      <appender-ref ref="aiAppender"  xdt:Transform="Remove"/>
+    <root xdt:Transform="Replace">
     </root>
   </log4net>
 

--- a/FlightJournal.Web/Web.Dev.config
+++ b/FlightJournal.Web/Web.Dev.config
@@ -41,10 +41,9 @@
   </system.web>
 
   <log4net>
-    <root>
-      <appender-ref ref="file" xdt:Transform="Remove"/>
-      <appender-ref ref="startland"  xdt:Transform="Remove"/>
-      <appender-ref ref="aiAppender"  xdt:Transform="Remove"/>
+    <root xdt:Transform="Replace">
+      <level value="ALL" />
+      <appender-ref ref="aiAppender"/>
     </root>
   </log4net>
 

--- a/FlightJournal.Web/Web.Release.config
+++ b/FlightJournal.Web/Web.Release.config
@@ -55,9 +55,9 @@
 
 
   <log4net>
-    <root>
-      <appender-ref ref="file" xdt:Transform="Remove"/>
-      <appender-ref ref="startland"  xdt:Transform="Remove"/>
+    <root xdt:Transform="Replace">
+      <level value="ALL" />
+      <appender-ref ref="aiAppender"/>
     </root>
   </log4net>
 

--- a/FlightJournal.Web/Web.config
+++ b/FlightJournal.Web/Web.config
@@ -194,7 +194,7 @@
       <maximumFileSize value="2MB" />
       <staticLogFileName value="false" />
       <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%utcdate{ISO8601} %level - %message%newline" />
+        <conversionPattern value="%utcdate{ISO8601}Z %level - %message%newline" />
       </layout>
     </appender>
 
@@ -213,7 +213,7 @@
       <maximumFileSize value="2MB" />
       <staticLogFileName value="false" />
       <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%utcdate{ISO8601} %level - %message%newline" />
+        <conversionPattern value="%utcdate{ISO8601}Z %level - %message%newline" />
       </layout>
     </appender>
 
@@ -231,7 +231,7 @@
 
     <appender name="aiAppender" type="Microsoft.ApplicationInsights.Log4NetAppender.ApplicationInsightsAppender, Microsoft.ApplicationInsights.Log4NetAppender">
       <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%utcdate{ISO8601} %level [%property{CONFIG}] - %message%newline" />
+        <conversionPattern value="%utcdate{ISO8601}Z %level [%property{CONFIG}] - %message%newline" />
       </layout>
       <InstrumentationKey name="AppInsightsKey" value="eae76f82-f524-4ed8-91e0-98e60ed43efc" />
     </appender>

--- a/FlightJournal.Web/Web.config
+++ b/FlightJournal.Web/Web.config
@@ -194,7 +194,7 @@
       <maximumFileSize value="2MB" />
       <staticLogFileName value="false" />
       <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %level - %message%newline" />
+        <conversionPattern value="%utcdate{ISO8601} %level - %message%newline" />
       </layout>
     </appender>
 
@@ -213,7 +213,7 @@
       <maximumFileSize value="2MB" />
       <staticLogFileName value="false" />
       <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date %level - %message%newline" />
+        <conversionPattern value="%utcdate{ISO8601} %level - %message%newline" />
       </layout>
     </appender>
 
@@ -231,7 +231,7 @@
 
     <appender name="aiAppender" type="Microsoft.ApplicationInsights.Log4NetAppender.ApplicationInsightsAppender, Microsoft.ApplicationInsights.Log4NetAppender">
       <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date %level - %message%newline" />
+        <conversionPattern value="%utcdate{ISO8601} %level [%property{CONFIG}] - %message%newline" />
       </layout>
       <InstrumentationKey name="AppInsightsKey" value="eae76f82-f524-4ed8-91e0-98e60ed43efc" />
     </appender>


### PR DESCRIPTION
Web.*.config repaired to do what I intended...
Logging uses UTC
Logged APRS timestamps use 'full' format with UTC offset (mainly for debugging).
APRS machinery is fed with UTC times.
Logging exceptions from autostart/land.

Various workarounds to make LINQ for EF happy. Interestingly enough, I saw different issues locally and on Azure. Yum.
