### PR TITLE
Fix for stale Flight object when returning from TrainingLog (Grading)

### DIFF
--- a/FlightJournal.Web/Controllers/FlightController.cs
+++ b/FlightJournal.Web/Controllers/FlightController.cs
@@ -317,7 +317,7 @@ namespace FlightJournal.Web.Controllers
         //
         // GET: /Flight/Edit/5
         [Authorize]
-        public ActionResult Edit(Guid? id)
+        public ActionResult Edit(Guid? id, string? referrer)
         {
             if(!id.HasValue)
                 return RedirectToAction("Grid");
@@ -339,6 +339,8 @@ namespace FlightJournal.Web.Controllers
             ViewBag.FlightId = id.Value;
             ViewBag.ChangeHistory = this.GetChangeHistory(id.Value);
             this.PopulateViewBag(flight);
+            if (referrer != null && Uri.TryCreate(referrer, UriKind.RelativeOrAbsolute, out var uri))
+                ViewBag.UrlReferrer = uri.ToString();
             return View(flight);
         }
 
@@ -407,10 +409,10 @@ namespace FlightJournal.Web.Controllers
             if (Request.QueryString[key] != null)
                 return Request.QueryString[key];
 
-            if (Request.UrlReferrer != null)
+            if (Request.UrlReferrer != null && Request.Url != Request.UrlReferrer)
                 return Request.UrlReferrer.ToString();
 
-            return "javascript:window.history.back();";
+            return "javascript:window.history.back();"; // this works oddly...
         }
 
         //

--- a/FlightJournal.Web/Views/Flight/Edit.cshtml
+++ b/FlightJournal.Web/Views/Flight/Edit.cshtml
@@ -17,13 +17,14 @@
                         <h4>Deleted @Model.Deleted.ToString() by @Model.LastUpdatedBy</h4>
                         <div class="btn-group">
                             @Html.ActionLink(_("Undo Delete"), "Enable", new { id = Model.FlightId, UrlReferrer = ViewBag.UrlReferrer }, new { @class = "btn btn-default btn-danger saving" })
-                            <a href="@ViewBag.UrlReferrer" class="btn btn-default leaving">@_("Back")</a>
+                            <a href="@ViewBag.UrlReferrer" class="btn btn-default back">@_("Back")</a>
                         </div>
                     </div>
                 </div>
             </div>
         }
         @Html.HiddenFor(model => model.FlightId)
+        @Html.HiddenFor(model => model.HasTrainingData)
         @Html.Hidden("UrlReferrer", (string)ViewBag.UrlReferrer)
         <div class="row">
             <div class="col-md-4 col-sm-6 col-xs-12">
@@ -156,7 +157,7 @@
             <div class="col-md-3">
                 <div class="btn-group btn-group-lg">
                     <input type="submit" value="@_("Save")" class="btn btn-primary saving" />
-                    <a href="@ViewBag.UrlReferrer" class="btn btn-default leaving">@_("Back")</a>
+                    <a href="@ViewBag.UrlReferrer" class="btn btn-default back">@_("Back")</a>
                 </div>
             </div>
             <div class="col-md-6">
@@ -176,10 +177,9 @@
                 </div>
             </div>
             @{
-                var btnclass = $"btn btn-default {(Request.IsInstructor() || User.IsAdministrator() ? "" : "disabled")}";
-
+                var btnclass = $"btn btn-default {(Request.IsInstructor() || User.IsAdministrator() ? "" : "disabled")} {(Model.HasTrainingData ? "withtrainingdata" : "")}";
                 <div class="col-md-3">
-                    <div class="btn-group btn-group-lg  leaving">
+                    <div class="btn-group btn-group-lg  totraining">
                         @Html.ActionLink(_("TrainingLog"), "Edit", "TrainingLog", new { flightId = Model.FlightId }, new { @class = btnclass }, "fa fa-graduation-cap")
                     </div>
                 </div>
@@ -276,8 +276,16 @@
             }
         }
 
-        $(document).ready(function() {
+        $(document).ready(function () {
+            if (sessionStorage.getItem("refresh") == "true") {
+                // we came from somewhere that may have updated  our model
+                sessionStorage.removeItem("refresh");
+                var referrer = (location.href.includes('?') ? "&" : "?") + "referrer=" + "@ViewBag.UrlReferrer";
+                location = location + referrer;
+            }
 
+            $("#test").click(function () {
+            });
             $("#PlaneId").combobox();
             $("#PilotId").combobox();
             $("#PilotBackseatId").combobox();
@@ -372,13 +380,24 @@
                 elvisHasLeftTheBuilding = true;
             });
 
-            $(".leaving").click(function() {
+            $(".back").click(function() {
                 if (
                     !isDirty
                     || confirm(@Html.Raw(__("You have unsaved data - do you want to leave the page and lose the changes?")))) {
                     isDirty = false;
                     elvisHasLeftTheBuilding = true;
                     window.history.back();
+                }
+            });
+
+
+            $(".totraining").click(function() {
+                if (
+                    !isDirty || confirm(@Html.Raw(__("You have unsaved data - do you want to leave the page and lose the changes?")))) {
+                    isDirty = false;
+                    elvisHasLeftTheBuilding = true;
+                } else {
+                    event.preventDefault();
                 }
             });
 

--- a/FlightJournal.Web/Views/Flight/Edit.cshtml
+++ b/FlightJournal.Web/Views/Flight/Edit.cshtml
@@ -284,8 +284,6 @@
                 location = location + referrer;
             }
 
-            $("#test").click(function () {
-            });
             $("#PlaneId").combobox();
             $("#PilotId").combobox();
             $("#PilotBackseatId").combobox();

--- a/FlightJournal.Web/Views/Flight/Grid.cshtml
+++ b/FlightJournal.Web/Views/Flight/Grid.cshtml
@@ -45,6 +45,12 @@
         var signalRflightsHub = $.connection.flightsHub;
 
         $(document).ready(function() {
+            if (sessionStorage.getItem("refresh") == "true") {
+                // we came from somewhere that may have updated  our model
+                sessionStorage.removeItem("refresh");
+                window.location.reload();
+            }
+
             configDataTables();
 
             $('a[data-toggle="tab"]').each(function() {

--- a/FlightJournal.Web/Views/TrainingLog/Edit.cshtml
+++ b/FlightJournal.Web/Views/TrainingLog/Edit.cshtml
@@ -420,6 +420,7 @@
                         function() {
                             console.debug("saving data");
                             initialStateOfInput = getStateOfInput(); // don't prompt again
+                            sessionStorage.setItem("refresh", "true"); // tell referrer to reload, we may have changed state (and messing with history stack causes odd side effects)
                             window.history.back();
                         },
                         function() {


### PR DESCRIPTION
When going back from TrainingLog, force the referrer (currently: Grid or flight Edit ) to reload, but (for flight Edit) in a way that preserves its referrer.
Just calling location.reload() sets referrer to itself, which we don't want.



Problemet var, at det nye HasTrainingData felt blev overskrevet, hvis man gik  via redigering af en flyvning, og trykkede Gem (selv om en Tilbage var nok). Det Flight object som var på Edit siden var forældet.


Det var lidt tricky, da man både skal fremtvinge en reload af der hvor man kom fra, og samtidig undgå at ødelægge Edit's UrlReferrer.



vi skal iøvrigt have kørt en stump SQL på Azure for at få det felt opdateret for gamle flyvninger:

`update Flights set HasExercise=true where FlightId in (select distinct FlightId from [dbo].[AppliedExercises] where [Grading_GradingId] != 5)`



og i princippet også 

`delete from [dbo].[AppliedExercises] where [Grading_GradingId] = 5`


