### PR TITLE
Let 48 hour editing window of a flight depend on creation time

### DIFF
--- a/FlightJournal.Web/Controllers/ReportController.cs
+++ b/FlightJournal.Web/Controllers/ReportController.cs
@@ -122,6 +122,10 @@ namespace FlightJournal.Web.Controllers
             // Allow f.Deleted != null
             rpt.DistinctLocations = rpt.Flights.Select(d => d.StartedFrom).Distinct().OrderBy(d=>d.Name);
 
+            ViewBag.EditableFlights = rpt.Flights
+                .ToList()
+                .Where(x => FlightController.UserCanEditFlight(db, x.FlightId, User))
+                .Select(x => x.FlightId);
             return this.View(rpt);
         }
 

--- a/FlightJournal.Web/Views/Report/Index.cshtml
+++ b/FlightJournal.Web/Views/Report/Index.cshtml
@@ -259,12 +259,9 @@
                             </td>
                         }
                         <td class="hidden-print text-right">
-                            @if (Request.IsPilot() && item.IsCurrentClubPilots())
+                            @if (Request.IsPilot() && item.IsCurrentClubPilots() && ((IEnumerable<Guid>)ViewBag.EditableFlights).Contains(item.FlightId))
                             {
-                                if (User.IsEditor() || item.Date.AddDays(3) >= DateTime.Now)
-                                {
-                                    @Html.ActionLink(_("Edit"), "Edit", "Flight", new { id = item.FlightId }, new { @class = "btn btn-default btn-xs" }, "fa fa-pencil-square-o fa-fw")
-                                }
+                                @Html.ActionLink(_("Edit"), "Edit", "Flight", new { id = item.FlightId }, new { @class = "btn btn-default btn-xs" }, "fa fa-pencil-square-o fa-fw")
                             }
                             @Html.ActionLink(_("Details"), "Details", "Flight", new { id = item.FlightId }, new { @class = "btn btn-default btn-xs" })
                         </td>


### PR DESCRIPTION
…, not flight time to allow for creation and editing of 'historical' flights.

Not the cleanest impl, but wanted to avoid adding a Flight.Created field, as the would have to be reconstructed from change history somewhere.