### PR TITLE
RestSharp rollback

### DIFF
--- a/FlightJournal.Tests/packages.config
+++ b/FlightJournal.Tests/packages.config
@@ -19,7 +19,7 @@
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net472" />
-  <package id="RestSharp" version="106.12.0" targetFramework="net45" />
+  <package id="RestSharp" version="105.0.1" targetFramework="net45" />
   <package id="System.Spatial" version="5.8.4" targetFramework="net472" />
   <package id="Twilio" version="3.6.27" targetFramework="net45" />
 </packages>

--- a/FlightJournal.Web/packages.config
+++ b/FlightJournal.Web/packages.config
@@ -65,7 +65,7 @@
   <package id="OptimizedPriorityQueue" version="4.2.0" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Respond" version="1.4.2" targetFramework="net45" />
-  <package id="RestSharp" version="106.12.0" targetFramework="net45" />
+  <package id="RestSharp" version="105.0.1" targetFramework="net45" />
   <package id="Skyhop.FlightAnalysis" version="2.0.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="5.0.0" targetFramework="net472" />


### PR DESCRIPTION
Rolling back RestSharp update - seems to break various stuff (phone number login, Pilot editing).

Verified (partially) by deploying to dev (actual phone# login not possible, but Pilot editing works again)
